### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Coveralls](http://img.shields.io/coveralls/jnbt/java-properties.png)](https://coveralls.io/r/jnbt/java-properties)
 [![RubyGems](http://img.shields.io/gem/v/java-properties.png)](http://rubygems.org/gems/java-properties)
 [![Gemnasium](http://img.shields.io/gemnasium/jnbt/java-properties.png)](https://gemnasium.com/jnbt/java-properties)
+[![Inline docs](http://inch-pages.github.io/github/jnbt/java-properties.png)](https://inch-pages.github.io/github/jnbt/java-properties)
 
 A ruby library to read and write [Java properties files](http://en.wikipedia.org/wiki/.properties).
 


### PR DESCRIPTION
I just added the badge you requested to your README: [![Inline docs](http://inch-pages.github.io/github/jnbt/java-properties.png)](https://inch-pages.github.io/github/jnbt/java-properties) (damn, you're such an overachiever :neckbeard:)

Your status page for this project is http://inch-pages.github.io/github/jnbt/java-properties/

Thank you for your support! 
