### PR TITLE
Handle escaped backslashes

### DIFF
--- a/lib/java-properties/encoding/special_chars.rb
+++ b/lib/java-properties/encoding/special_chars.rb
@@ -10,7 +10,8 @@ module JavaProperties
         "\t" => '\\t',
         "\r" => '\\r',
         "\n" => '\\n',
-        "\f" => '\\f'
+        "\f" => '\\f',
+        "\\" => '\\\\',
       }.freeze
 
       # Lookup table to remove escaping from special chars

--- a/spec/fixtures/test.properties
+++ b/spec/fixtures/test.properties
@@ -34,3 +34,5 @@ item10=test\n\ttest\u0050 \
 item11=a\u00e4b \ud868\udc2f
 
 item12=#no comment
+
+item13=with\\back\\nslash\\t

--- a/spec/fixtures/test_normalized.properties
+++ b/spec/fixtures/test_normalized.properties
@@ -11,3 +11,4 @@ item9=line 1 line 2 line 3
 item10=test\n\ttest\u0050 test\n\ttest test\n\ttest = test
 item11=a\u00e4b \ud868\udc2f
 item12=#no comment
+item13=with\\back\\nslash\\t

--- a/spec/java-properties/encoding/special_chars_spec.rb
+++ b/spec/java-properties/encoding/special_chars_spec.rb
@@ -2,15 +2,15 @@ require 'helper'
 
 describe JavaProperties::Encoding::SpecialChars do
   subject{ JavaProperties::Encoding::SpecialChars }
-  let(:raw)    { "this is some \n text \t with special\r chars\f" }
-  let(:encoded){ 'this is some \n text \t with special\r chars\f' }
+  let(:raw)    { "this\\is some \n text \t wi\\th special\r chars\f" }
+  let(:encoded){ 'this\\\\is some \n text \t wi\\\\th special\r chars\f' }
 
   it "encodes special chars" do
     processed = subject.encode!(raw.dup)
     _(processed).must_equal encoded
   end
 
-  it "deencodes special chars" do
+  it "decodes special chars" do
     processed = subject.decode!(encoded.dup)
     _(processed).must_equal raw
   end
@@ -19,5 +19,12 @@ describe JavaProperties::Encoding::SpecialChars do
     encoded  = subject.encode!(raw.dup)
     deconded = subject.decode!(encoded)
     _(deconded).must_equal raw
+  end
+
+  it "handled backslash escpaing" do
+    decoded = subject.decode!('some\\\\test\\\\')
+    _(decoded).must_equal 'some\\test\\'
+    encoded = subject.encode!('some\\test\\')
+    _(encoded).must_equal 'some\\\\test\\\\'
   end
 end

--- a/spec/java-properties/parsing/parser_spec.rb
+++ b/spec/java-properties/parsing/parser_spec.rb
@@ -18,6 +18,7 @@ describe JavaProperties::Parsing::Parser do
       :item10 => "test\n\ttestP test\n\ttest test\n\ttest = test",
       :item11 => "aäb 𪀯",
       :item12 => "#no comment",
+      :item13 => "with\\back\\nslash\\t",
     }
   end
 


### PR DESCRIPTION
Fixes #13 

Java uses escaped sequences of backslashes when reading and writing properties files