### PR TITLE
Change gemspec to allow installation on Ruby 3.0 and all future versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
   - ruby-head
 before_install:
-  - gem install bundler:2.1.4
+  - gem install bundler:2.2.11
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/java-properties.gemspec
+++ b/java-properties.gemspec
@@ -1,7 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'java-properties/version'
+# frozen_string_literal: true
+
+require_relative 'lib/java-properties/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'java-properties'
@@ -19,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files = Dir.glob('spec/fixtures/**/*.properties')
 
   spec.required_rubygems_version = '>= 1.3.5'
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'inch', '~> 0.8'


### PR DESCRIPTION
This change allows the gem to be installed on Ruby 3.0 and all future
versions. It also loads the gem version directly using a relative path
and removes encoding comment as UTF-8 is a default encoding in Ruby 2.0.